### PR TITLE
hiding internals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! and partially RFC3339.
 //!
 //! Validity of a given date is not guaranteed, this parser will happily parse
-//! 2015.02.29 as a valid date,
+//! `"2015-02-29"` as a valid date,
 //! even though 2015 was no leap year.
 //!
 //! # Example

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,3 +1,13 @@
+//! This module is strictly internal.
+//!
+//! These functions are used by `date()`, `time()` and `datetime()`.
+//! They are currently not private, because the need to be accessible,
+//! but are not useful by themselves.
+//!
+//! Please refer to the top-level functions instead, as they offer a better abstraction.
+//!
+//! **These functions may be made private later.**
+
 use helper::*;
 use nom::{self, is_digit};
 use super::{Time, DateTime, Date};

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,40 +6,6 @@ use nom::IResult::*;
 use iso8601::*;
 use iso8601::parsers::*;
 
-#[test]
-fn test_year() {
-    assert_eq!(Done(&[][..],   2015), year(b"2015"));
-    assert_eq!(Done(&[][..],  -0333), year(b"-0333"));
-    assert_eq!(Done(&b"-"[..], 2015), year(b"2015-"));
-
-    assert!(year(b"abcd").is_err());
-    assert!(year(b"2a03").is_err());
-}
-
-#[test]
-fn test_month() {
-    assert_eq!(Done(&[][..], 1),    month(b"01"));
-    assert_eq!(Done(&[][..], 6),    month(b"06"));
-    assert_eq!(Done(&[][..], 12),   month(b"12"));
-    assert_eq!(Done(&b"-"[..], 12), month(b"12-"));
-
-    assert!(month(b"13").is_err());
-    assert!(month(b"00").is_err());
-}
-
-#[test]
-fn test_day() {
-    assert_eq!(Done(&[][..], 1),    day(b"01"));
-    assert_eq!(Done(&[][..], 12),   day(b"12"));
-    assert_eq!(Done(&[][..], 20),   day(b"20"));
-    assert_eq!(Done(&[][..], 28),   day(b"28"));
-    assert_eq!(Done(&[][..], 30),   day(b"30"));
-    assert_eq!(Done(&[][..], 31),   day(b"31"));
-    assert_eq!(Done(&b"-"[..], 31), day(b"31-"));
-
-    assert!(day(b"00").is_err());
-    assert!(day(b"32").is_err());
-}
 
 #[test]
 fn test_date() {
@@ -49,45 +15,6 @@ fn test_date() {
     assert!(parse_date(b"201").is_incomplete());
     assert!(parse_date(b"2015p00p00").is_err());
     assert!(parse_date(b"pppp").is_err());
-}
-
-#[test]
-fn test_hour() {
-    assert_eq!(Done(&[][..], 0),  hour(b"00"));
-    assert_eq!(Done(&[][..], 1),  hour(b"01"));
-    assert_eq!(Done(&[][..], 6),  hour(b"06"));
-    assert_eq!(Done(&[][..], 12), hour(b"12"));
-    assert_eq!(Done(&[][..], 13), hour(b"13"));
-    assert_eq!(Done(&[][..], 20), hour(b"20"));
-    assert_eq!(Done(&[][..], 24), hour(b"24"));
-
-    assert!(hour(b"25").is_err());
-    assert!(hour(b"30").is_err());
-    assert!(hour(b"ab").is_err());
-}
-
-#[test]
-fn test_minute() {
-    assert_eq!(Done(&[][..], 0),  minute(b"00"));
-    assert_eq!(Done(&[][..], 1),  minute(b"01"));
-    assert_eq!(Done(&[][..], 30), minute(b"30"));
-    assert_eq!(Done(&[][..], 59), minute(b"59"));
-
-    assert!(minute(b"60").is_err());
-    assert!(minute(b"61").is_err());
-    assert!(minute(b"ab").is_err());
-}
-
-#[test]
-fn test_second() {
-    assert_eq!(Done(&[][..], 0),  second(b"00"));
-    assert_eq!(Done(&[][..], 1),  second(b"01"));
-    assert_eq!(Done(&[][..], 30), second(b"30"));
-    assert_eq!(Done(&[][..], 59), second(b"59"));
-    assert_eq!(Done(&[][..], 60), second(b"60"));
-
-    assert!(second(b"61").is_err());
-    assert!(second(b"ab").is_err());
 }
 
 #[test]


### PR DESCRIPTION
this just hides a bunch of the small parser functions, which are undocumentable, by making them private.
I had to pull a lot of the tests into `parsers.rs`, thats why this change looks big, infact it isn't