### PR TITLE
Nom 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 
 [dependencies]
-nom = "1.0.0"
+nom = "2.0"
 clippy = {version = "*", optional = true}
 
 [features]

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -160,8 +160,8 @@ named!(pub parse_time <Time>, do_parse!(
         h: hour >>
         opt!(complete!(tag!(":"))) >>
         m: minute >>
-        s:  opt!(complete!( do_parse!( opt!(tag!(":")) >> s:second >> (s)))) >>
-        ms: opt!(complete!( do_parse!( tag!(".") >> ms:millisecond >> (ms)))) >>
+        s:  opt!(complete!( preceded!(opt!(tag!(":")), second))) >>
+        ms: opt!(complete!( preceded!(tag!("."), millisecond))) >>
         z:  opt!(complete!( alt!( timezone_hour | timezone_utc) )) >>
         (
             Time {
@@ -185,7 +185,7 @@ named!(timezone_hour <(i32,i32)>, do_parse!(
         s: sign >>
         h: hour >>
         m: empty_or!(
-            do_parse!(opt!(tag!(":")) >> m: minute >> ( m ))
+            preceded!(opt!(tag!(":")), minute)
            ) >>
         ( (s * (h as i32) , s * (m.unwrap_or(0) as i32)) )
         ));

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -39,7 +39,7 @@ macro_rules! check(
         }
       }
       if failed {
-        nom::IResult::Error(nom::Err::Position(nom::ErrorKind::Custom(20),$input))
+        nom::IResult::Error(nom::ErrorKind::Custom(20))
       } else {
         nom::IResult::Done(&b""[..], $input)
       }


### PR DESCRIPTION
This is a patch to enable compatibility with nom 2.0
It switches from the `chain!` macro to the nicer `do_parse!` macro, but otherwise remains unchanged.

This will not be merged until a nom 2.0 release is cut, at which point it will not point to the git version anymore (*this means this branch will be force-pushed to, to remove that commit*)