### PR TITLE
Fix broken Time#set_tz method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl Time {
     pub fn set_tz(&self, tzo: (i32, i32)) -> Time {
         let mut t = *self;
         t.tz_offset_hours = tzo.0;
-        t.tz_offset_hours = tzo.1;
+        t.tz_offset_minutes = tzo.1;
         t
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -53,6 +53,28 @@ fn test_time() {
 }
 
 #[test]
+fn test_time_set_tz() {
+    let original = Time {
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+        tz_offset_hours: 0,
+        tz_offset_minutes: 0
+    };
+    let expected = Time {
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+        tz_offset_hours: 2,
+        tz_offset_minutes: 30
+    };
+
+    assert_eq!(expected, original.set_tz((2, 30)));
+}
+
+#[test]
 fn short_time1() {
     assert_eq!(parse_time(b"1648"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }));
 }


### PR DESCRIPTION
I was reading this crate as it seemed like a really concise `nom` example, when I stumbled across this weird looking method which never sets `tz_offset_minutes`.  

```rust
    pub fn set_tz(&self, tzo: (i32, i32)) -> Time {
        let mut t = *self;
        t.tz_offset_hours = tzo.0;
        t.tz_offset_hours = tzo.1;
        t
    }
```

The method isn't actually used anywhere, but I figured might as well offer a PR to fix it.  (Up to you whether the method should just be deleted entirely)