### PR TITLE
update to nom 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 
 [dependencies]
-nom = "3.2"
+nom = "4.0.0-beta1"
 clippy = {version = ">0.0.0", optional = true}
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ impl FromStr for DateTime {
 /// let date = iso8601::date("2015-11-02").unwrap();
 /// ```
 pub fn date(string: &str) -> Result<Date, String> {
-    if let Ok((_, parsed)) = parsers::parse_date(string.as_bytes()) {
+    if let Ok((_, parsed)) = parsers::parse_date(nom::types::CompleteByteSlice(string.as_bytes())) {
         Ok(parsed)
     } else {
         Err(format!("Parser Error: {}", string))
@@ -149,7 +149,7 @@ pub fn date(string: &str) -> Result<Date, String> {
 /// let time = iso8601::time("21:56:42").unwrap();
 /// ```
 pub fn time(string: &str) -> Result<Time, String> {
-    if let Ok((_, parsed)) = parsers::parse_time(string.as_bytes()) {
+    if let Ok((_, parsed)) = parsers::parse_time(nom::types::CompleteByteSlice(string.as_bytes())) {
         Ok(parsed)
     } else {
         Err(format!("Parser Error: {}", string))
@@ -169,7 +169,7 @@ pub fn time(string: &str) -> Result<Time, String> {
 /// let dt = iso8601::datetime("2015-11-03T21:56").unwrap();
 /// ```
 pub fn datetime(string: &str) -> Result<DateTime, String> {
-    if let Ok((_left_overs, parsed)) = parsers::parse_datetime(string.as_bytes()) {
+    if let Ok((_left_overs, parsed)) = parsers::parse_datetime(nom::types::CompleteByteSlice(string.as_bytes())) {
         Ok(parsed)
     } else {
         Err(format!("Parser Error: {}", string))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 
 #[macro_use]
 extern crate nom;
-use nom::IResult::*;
 
 use std::default::Default;
 use std::str::FromStr;
@@ -127,7 +126,7 @@ impl FromStr for DateTime {
 /// let date = iso8601::date("2015-11-02").unwrap();
 /// ```
 pub fn date(string: &str) -> Result<Date, String> {
-    if let Done(_, parsed) = parsers::parse_date(string.as_bytes()) {
+    if let Ok((_, parsed)) = parsers::parse_date(string.as_bytes()) {
         Ok(parsed)
     } else {
         Err(format!("Parser Error: {}", string))
@@ -150,7 +149,7 @@ pub fn date(string: &str) -> Result<Date, String> {
 /// let time = iso8601::time("21:56:42").unwrap();
 /// ```
 pub fn time(string: &str) -> Result<Time, String> {
-    if let Done(_, parsed) = parsers::parse_time(string.as_bytes()) {
+    if let Ok((_, parsed)) = parsers::parse_time(string.as_bytes()) {
         Ok(parsed)
     } else {
         Err(format!("Parser Error: {}", string))
@@ -170,7 +169,7 @@ pub fn time(string: &str) -> Result<Time, String> {
 /// let dt = iso8601::datetime("2015-11-03T21:56").unwrap();
 /// ```
 pub fn datetime(string: &str) -> Result<DateTime, String> {
-    if let Done(_left_overs, parsed) = parsers::parse_datetime(string.as_bytes()) {
+    if let Ok((_left_overs, parsed)) = parsers::parse_datetime(string.as_bytes()) {
         Ok(parsed)
     } else {
         Err(format!("Parser Error: {}", string))

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -16,12 +16,13 @@ use std::str::{self, FromStr};
 macro_rules! empty_or(
     ($i:expr, $submac:ident!( $($args:tt)* )) => (
         if $i.len() == 0 {
-            nom::IResult::Done($i, None)
+            Ok(($i, None))
         } else {
             match $submac!($i, $($args)*) {
-                nom::IResult::Done(i,o)     => nom::IResult::Done(i, Some(o)),
-                nom::IResult::Error(_)      => nom::IResult::Done($i, None),
-                nom::IResult::Incomplete(i) => nom::IResult::Incomplete(i)
+                Ok((i,o))     => Ok((i, Some(o))),
+                Err(nom::Err::Error(_))      => Ok(($i, None)),
+                Err(nom::Err::Failure(_))    => Ok(($i, None)),
+                Err(nom::Err::Incomplete(i)) => Err(nom::Err::Incomplete(i))
 
             }
         }
@@ -40,9 +41,9 @@ macro_rules! check(
         }
       }
       if failed {
-        nom::IResult::Error(nom::ErrorKind::Custom(20))
+        Err(nom::Err::Error(error_position!($input, nom::ErrorKind::Custom(20u32))))
       } else {
-        nom::IResult::Done(&b""[..], $input)
+        Ok((&b""[..], $input))
       }
     }
   );
@@ -65,7 +66,7 @@ named!(take_4_digits, flat_map!(take!(4), check!(is_digit)));
 // year
 named!(year_prefix, alt!(tag!("+") | tag!("-")));
 named!(year <i32>, do_parse!(
-        pref: opt!(complete!(year_prefix)) >>
+        pref: opt!(year_prefix) >>
         year: call!(take_4_digits) >>
         (
             match pref {
@@ -107,9 +108,9 @@ named!(ord_day <u32>, do_parse!(
 // YYYY-MM-DD
 named!(pub ymd_date <Date>, do_parse!(
         y: year >>
-        opt!(complete!(tag!("-"))) >>
+        opt!(tag!("-")) >>
         m: month >>
-        opt!(complete!(tag!("-"))) >>
+        opt!(tag!("-")) >>
         d: day >>
         ( Date::YMD{ year: y, month: m, day: d } )
         ));
@@ -117,7 +118,7 @@ named!(pub ymd_date <Date>, do_parse!(
 // YYYY-MM-DD
 named!(pub ordinal_date <Date>, do_parse!(
         y: year >>
-        opt!(complete!(tag!("-"))) >>
+        opt!(tag!("-")) >>
         d: ord_day >>
         ( Date::Ordinal{ year: y, ddd: d } )
         ));
@@ -125,10 +126,10 @@ named!(pub ordinal_date <Date>, do_parse!(
 // YYYY-"W"WW-D
 named!(pub iso_week_date <Date>, do_parse!(
         y: year >>
-        opt!(complete!(tag!("-"))) >>
+        opt!(tag!("-")) >>
         tag!("W") >>
         w: week >>
-        opt!(complete!(tag!("-"))) >>
+        opt!(tag!("-")) >>
         d: week_day >>
         ( Date::Week{ year: y, ww: w, d: d } )
         ));
@@ -170,11 +171,11 @@ fn millisecond(fraction: f32) -> u32 {
 // HH:MM:[SS][.(m*)][(Z|+...|-...)]
 named!(pub parse_time <Time>, do_parse!(
         h: hour >>
-        opt!(complete!(tag!(":"))) >>
+        opt!(tag!(":")) >>
         m: minute >>
-        s:  opt!(complete!( preceded!(opt!(tag!(":")), second))) >>
-        ms: opt!(complete!( map!(preceded!(one_of!(",."), fractions), millisecond))) >>
-        z:  opt!(complete!( alt!( timezone_hour | timezone_utc) )) >>
+        s:  opt!(preceded!(opt!(tag!(":")), second)) >>
+        ms: opt!( map!(preceded!(one_of!(",."), fractions), millisecond)) >>
+        z:  opt!( alt!( timezone_hour | timezone_utc) ) >>
         (
             Time {
                 hour: h,
@@ -222,23 +223,22 @@ mod tests{
 
     use super::{year, month, day};
     use super::{hour, minute, second};
-    use nom::IResult::*;
 
     #[test]
     fn test_year() {
-        assert_eq!(Done(&[][..],   2015), year(b"2015"));
-        assert_eq!(Done(&[][..],  -0333), year(b"-0333"));
-        assert_eq!(Done(&b"-"[..], 2015), year(b"2015-"));
+        assert_eq!(Ok((&[][..],   2015)), year(b"2015"));
+        assert_eq!(Ok((&[][..],  -0333)), year(b"-0333"));
+        assert_eq!(Ok((&b"-"[..], 2015)), year(b"2015-"));
         assert!(year(b"abcd").is_err());
         assert!(year(b"2a03").is_err());
     }
 
     #[test]
     fn test_month() {
-        assert_eq!(Done(&[][..], 1),    month(b"01"));
-        assert_eq!(Done(&[][..], 6),    month(b"06"));
-        assert_eq!(Done(&[][..], 12),   month(b"12"));
-        assert_eq!(Done(&b"-"[..], 12), month(b"12-"));
+        assert_eq!(Ok((&[][..], 1)),    month(b"01"));
+        assert_eq!(Ok((&[][..], 6)),    month(b"06"));
+        assert_eq!(Ok((&[][..], 12)),   month(b"12"));
+        assert_eq!(Ok((&b"-"[..], 12)), month(b"12-"));
 
         assert!(month(b"13").is_err());
         assert!(month(b"00").is_err());
@@ -246,13 +246,13 @@ mod tests{
 
     #[test]
     fn test_day() {
-        assert_eq!(Done(&[][..], 1),    day(b"01"));
-        assert_eq!(Done(&[][..], 12),   day(b"12"));
-        assert_eq!(Done(&[][..], 20),   day(b"20"));
-        assert_eq!(Done(&[][..], 28),   day(b"28"));
-        assert_eq!(Done(&[][..], 30),   day(b"30"));
-        assert_eq!(Done(&[][..], 31),   day(b"31"));
-        assert_eq!(Done(&b"-"[..], 31), day(b"31-"));
+        assert_eq!(Ok((&[][..], 1)),    day(b"01"));
+        assert_eq!(Ok((&[][..], 12)),   day(b"12"));
+        assert_eq!(Ok((&[][..], 20)),   day(b"20"));
+        assert_eq!(Ok((&[][..], 28)),   day(b"28"));
+        assert_eq!(Ok((&[][..], 30)),   day(b"30"));
+        assert_eq!(Ok((&[][..], 31)),   day(b"31"));
+        assert_eq!(Ok((&b"-"[..], 31)), day(b"31-"));
 
         assert!(day(b"00").is_err());
         assert!(day(b"32").is_err());
@@ -260,13 +260,13 @@ mod tests{
 
     #[test]
     fn test_hour() {
-        assert_eq!(Done(&[][..], 0),  hour(b"00"));
-        assert_eq!(Done(&[][..], 1),  hour(b"01"));
-        assert_eq!(Done(&[][..], 6),  hour(b"06"));
-        assert_eq!(Done(&[][..], 12), hour(b"12"));
-        assert_eq!(Done(&[][..], 13), hour(b"13"));
-        assert_eq!(Done(&[][..], 20), hour(b"20"));
-        assert_eq!(Done(&[][..], 24), hour(b"24"));
+        assert_eq!(Ok((&[][..], 0)),  hour(b"00"));
+        assert_eq!(Ok((&[][..], 1)),  hour(b"01"));
+        assert_eq!(Ok((&[][..], 6)),  hour(b"06"));
+        assert_eq!(Ok((&[][..], 12)), hour(b"12"));
+        assert_eq!(Ok((&[][..], 13)), hour(b"13"));
+        assert_eq!(Ok((&[][..], 20)), hour(b"20"));
+        assert_eq!(Ok((&[][..], 24)), hour(b"24"));
 
         assert!(hour(b"25").is_err());
         assert!(hour(b"30").is_err());
@@ -275,10 +275,10 @@ mod tests{
 
     #[test]
     fn test_minute() {
-        assert_eq!(Done(&[][..], 0),  minute(b"00"));
-        assert_eq!(Done(&[][..], 1),  minute(b"01"));
-        assert_eq!(Done(&[][..], 30), minute(b"30"));
-        assert_eq!(Done(&[][..], 59), minute(b"59"));
+        assert_eq!(Ok((&[][..], 0)),  minute(b"00"));
+        assert_eq!(Ok((&[][..], 1)),  minute(b"01"));
+        assert_eq!(Ok((&[][..], 30)), minute(b"30"));
+        assert_eq!(Ok((&[][..], 59)), minute(b"59"));
 
         assert!(minute(b"60").is_err());
         assert!(minute(b"61").is_err());
@@ -287,11 +287,11 @@ mod tests{
 
     #[test]
     fn test_second() {
-        assert_eq!(Done(&[][..], 0),  second(b"00"));
-        assert_eq!(Done(&[][..], 1),  second(b"01"));
-        assert_eq!(Done(&[][..], 30), second(b"30"));
-        assert_eq!(Done(&[][..], 59), second(b"59"));
-        assert_eq!(Done(&[][..], 60), second(b"60"));
+        assert_eq!(Ok((&[][..], 0)),  second(b"00"));
+        assert_eq!(Ok((&[][..], 1)),  second(b"01"));
+        assert_eq!(Ok((&[][..], 30)), second(b"30"));
+        assert_eq!(Ok((&[][..], 59)), second(b"59"));
+        assert_eq!(Ok((&[][..], 60)), second(b"60"));
 
         assert!(second(b"61").is_err());
         assert!(second(b"ab").is_err());

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,53 +5,59 @@ extern crate nom;
 
 use iso8601::*;
 use iso8601::parsers::*;
+use nom::types::CompleteByteSlice;
 
+// alias the type for readability
+type Input<'a> = CompleteByteSlice<'a>;
+pub fn Input<'a>(input:&'a[u8]) -> Input<'a> {
+  CompleteByteSlice(input)
+}
 
 #[test]
 fn test_date() {
-    assert_eq!(Ok((&[][..], Date::YMD { year: 2015, month: 6, day: 26, })), parse_date(b"2015-06-26"));
-    assert_eq!(Ok((&[][..], Date::YMD { year: -333, month: 7, day: 11, })), parse_date(b"-0333-07-11"));
+    assert_eq!(Ok((Input(&[][..]), Date::YMD { year: 2015, month: 6, day: 26, })), parse_date(Input(b"2015-06-26")));
+    assert_eq!(Ok((Input(&[][..]), Date::YMD { year: -333, month: 7, day: 11, })), parse_date(Input(b"-0333-07-11")));
 
-    assert!(parse_date(b"201").unwrap_err().is_incomplete());
-    assert!(parse_date(b"2015p00p00").is_err());
-    assert!(parse_date(b"pppp").is_err());
+    assert!(parse_date(Input(b"201")).is_err());
+    assert!(parse_date(Input(b"2015p00p00")).is_err());
+    assert!(parse_date(Input(b"pppp")).is_err());
 }
 
 #[test]
 fn test_millisecond() {
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 100,    tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00.1"));
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 120,   tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00.12"));
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 123,  tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00.123"));
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00.4321"));
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43.4321"));
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 11,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:11.4321"));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second:  0,  millisecond: 100,    tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(Input(b"16:43:00.1")));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second:  0,  millisecond: 120,   tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(Input(b"16:43:00.12")));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second:  0,  millisecond: 123,  tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(Input(b"16:43:00.123")));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second:  0,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(Input(b"16:43:00.4321")));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second:  0,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(Input(b"16:43.4321")));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second: 11,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(Input(b"16:43:11.4321")));
 
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 100,    tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00,1"));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second:  0,  millisecond: 100,    tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(Input(b"16:43:00,1")));
 
     assert_eq!(
-        Ok((&[][..],  Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),
-        parse_time(b"04:05:06.12345")
+        Ok((Input(&[][..]),  Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),
+        parse_time(Input(b"04:05:06.12345"))
         );
 
     assert_eq!(
-        Ok((&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})),
-        parse_datetime(b"2001-W05-6T04:05:06.12345Z")
+        Ok((Input(&[][..]), DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})),
+        parse_datetime(Input(b"2001-W05-6T04:05:06.12345Z"))
         );
 
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(b"16:43:16.123"));
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(b"16:43:16.123+00:00"));
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(b"16:43:16.123-00:00"));
-    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 5, tz_offset_minutes: 0})),  parse_time(b"16:43:16.123+05:00"));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(Input(b"16:43:16.123")));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(Input(b"16:43:16.123+00:00")));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(Input(b"16:43:16.123-00:00")));
+    assert_eq!(Ok((Input(&[][..]), Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 5, tz_offset_minutes: 0})),  parse_time(Input(b"16:43:16.123+05:00")));
 }
 
 #[test]
 fn test_time() {
-    assert_eq!(parse_time(b"16:43:16"), Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })) );
-    assert_eq!(parse_time(b"16:43"),    Ok((&[][..], Time { hour: 16, minute: 43, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })) );
+    assert_eq!(parse_time(Input(b"16:43:16")), Ok((Input(&[][..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })) );
+    assert_eq!(parse_time(Input(b"16:43")),    Ok((Input(&[][..]), Time { hour: 16, minute: 43, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })) );
 
-    assert!(parse_time(b"20:").unwrap_err().is_incomplete());
-    assert!(parse_time(b"20p42p16").is_err());
-    assert!(parse_time(b"pppp").is_err());
+    assert!(parse_time(Input(b"20:")).is_err());
+    assert!(parse_time(Input(b"20p42p16")).is_err());
+    assert!(parse_time(Input(b"pppp")).is_err());
 }
 
 #[test]
@@ -78,54 +84,54 @@ fn test_time_set_tz() {
 
 #[test]
 fn short_time1() {
-    assert_eq!(parse_time(b"1648"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"1648")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time2() {
-    assert_eq!(parse_time(b"16:48"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"16:48")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time3() {
-    assert_eq!(parse_time(b"16:48Z"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"16:48Z")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time4() {
-    assert_eq!(parse_time(b"164800"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"164800")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time5() {
-    assert_eq!(parse_time(b"164800.1"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 100, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"164800.1")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 100, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time6() {
-    assert_eq!(parse_time(b"164800.1Z"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 100, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"164800.1Z")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 100, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time7() {
-    assert_eq!(parse_time(b"16:48:00"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"16:48:00")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 
 #[test]
 fn short_twtz1() {
-    assert_eq!(parse_time(b"1648Z"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"1648Z")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_twtz2() {
-    assert_eq!(parse_time(b"16:48Z"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
+    assert_eq!(parse_time(Input(b"16:48Z")), Ok((Input(&[][..]), Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 
 #[test]
 fn short_dtim1() {
-    assert_eq!(parse_datetime(b"20070831T1648"), Ok((&[][..], DateTime { date: Date::YMD { year: 2007, month: 08, day: 31, }, time: Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, } })));
+    assert_eq!(parse_datetime(Input(b"20070831T1648")), Ok((Input(&[][..]), DateTime { date: Date::YMD { year: 2007, month: 08, day: 31, }, time: Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, } })));
 }
 #[test]
 fn short_dtim2() {
-    assert_eq!(parse_datetime(b"20070831T1648Z"), Ok((&[][..], DateTime { date: Date::YMD { year: 2007, month: 08, day: 31, }, time: Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }, })));
+    assert_eq!(parse_datetime(Input(b"20070831T1648Z")), Ok((Input(&[][..]), DateTime { date: Date::YMD { year: 2007, month: 08, day: 31, }, time: Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }, })));
 }
 #[test]
 fn short_dtim3() {
-    assert_eq!(parse_datetime(b"2008-12-24T18:21Z"),
-               Ok((&[][..],
+    assert_eq!(parse_datetime(Input(b"2008-12-24T18:21Z")),
+               Ok((Input(&[][..]),
                     DateTime {
                         date: Date::YMD {
                             year: 2008,
@@ -145,80 +151,80 @@ fn short_dtim3() {
 
 #[test]
 fn test_time_with_timezone() {
-    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16"));
-    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16Z"));
-    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16+00:00"));
-    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16-00:00"));
-    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0, })), parse_time(b"16:43:16+05:00"));
-    assert_eq!(Ok((&b"+"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16+"));
-    assert_eq!(Ok((&b"+0"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16+0"));
-    assert_eq!(Ok((&b"+05:"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16+05:"));
+    assert_eq!(Ok((Input(&[][..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(Input(b"16:43:16")));
+    assert_eq!(Ok((Input(&[][..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(Input(b"16:43:16Z")));
+    assert_eq!(Ok((Input(&[][..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(Input(b"16:43:16+00:00")));
+    assert_eq!(Ok((Input(&[][..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(Input(b"16:43:16-00:00")));
+    assert_eq!(Ok((Input(&[][..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0, })), parse_time(Input(b"16:43:16+05:00")));
+    assert_eq!(Ok((Input(&b"+"[..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(Input(b"16:43:16+")));
+    assert_eq!(Ok((Input(&b"+0"[..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(Input(b"16:43:16+0")));
+    assert_eq!(Ok((Input(&b"+05:"[..]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(Input(b"16:43:16+05:")));
 
-    assert!(parse_time(b"20:").unwrap_err().is_incomplete());
-    assert!(parse_time(b"20p42p16").is_err());
-    assert!(parse_time(b"pppp").is_err());
+    assert!(parse_time(Input(b"20:")).unwrap_err().is_incomplete());
+    assert!(parse_time(Input(b"20p42p16")).is_err());
+    assert!(parse_time(Input(b"pppp")).is_err());
 }
 
 #[test]
 fn test_iso_week_date() {
-    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 5, d: 7, })), iso_week_date(b"2015-W05-7"));
-    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(b"2015-W06-6"));
-    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(b"2015-W066"));
-    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(b"2015W066"));
-    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 43, d: 6, })), iso_week_date(b"2015-W43-6"));
+    assert_eq!(Ok((Input(&[][..]), Date::Week { year: 2015, ww: 5, d: 7, })), iso_week_date(Input(b"2015-W05-7")));
+    assert_eq!(Ok((Input(&[][..]), Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(Input(b"2015-W06-6")));
+    assert_eq!(Ok((Input(&[][..]), Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(Input(b"2015-W066")));
+    assert_eq!(Ok((Input(&[][..]), Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(Input(b"2015W066")));
+    assert_eq!(Ok((Input(&[][..]), Date::Week { year: 2015, ww: 43, d: 6, })), iso_week_date(Input(b"2015-W43-6")));
 
-    assert!(iso_week_date(b"2015-W06-8").is_err());
-    assert!(iso_week_date(b"2015-W068").is_err());
-    assert!(iso_week_date(b"2015-W06-0").is_err());
-    assert!(iso_week_date(b"2015-W00-2").is_err());
-    assert!(iso_week_date(b"2015-W54-2").is_err());
-    assert!(iso_week_date(b"2015-W542").is_err());
+    assert!(iso_week_date(Input(b"2015-W06-8")).is_err());
+    assert!(iso_week_date(Input(b"2015-W068")).is_err());
+    assert!(iso_week_date(Input(b"2015-W06-0")).is_err());
+    assert!(iso_week_date(Input(b"2015-W00-2")).is_err());
+    assert!(iso_week_date(Input(b"2015-W54-2")).is_err());
+    assert!(iso_week_date(Input(b"2015-W542")).is_err());
 }
 
 #[test]
 fn test_ordinal_date() {
-    assert_eq!(Ok((&[][..], Date::Ordinal { year: 2015, ddd: 57, })),  ordinal_date(b"2015-057"));
+    assert_eq!(Ok((Input(&[][..]), Date::Ordinal { year: 2015, ddd: 57, })),  ordinal_date(Input(b"2015-057")));
 
     // not valid, but this should be tested elsewhere
-    assert_eq!(Ok((&[][..], Date::Ordinal { year: 2015, ddd: 358, })), ordinal_date(b"2015-358"));
-    assert_eq!(Ok((&[][..], Date::Ordinal { year: 2015, ddd: 399, })), ordinal_date(b"2015-399"));
-    assert_eq!(Ok((&[][..], Date::Ordinal { year: 2015, ddd: 000, })), ordinal_date(b"2015-000"));
+    assert_eq!(Ok((Input(&[][..]), Date::Ordinal { year: 2015, ddd: 358, })), ordinal_date(Input(b"2015-358")));
+    assert_eq!(Ok((Input(&[][..]), Date::Ordinal { year: 2015, ddd: 399, })), ordinal_date(Input(b"2015-399")));
+    assert_eq!(Ok((Input(&[][..]), Date::Ordinal { year: 2015, ddd: 000, })), ordinal_date(Input(b"2015-000")));
 
     // not valid here either
-    assert!(ordinal_date(b"2015-400").is_err());
+    assert!(ordinal_date(Input(b"2015-400")).is_err());
 }
 
 #[test]
 fn format_equivalence() {
-    assert_eq!(parse_datetime(b"2001-02-03T04:05:06+07:00"),  parse_datetime(b"20010203T040506+0700"));
-    assert_eq!(parse_datetime(b"2001-02-03T04:05:06+07:00"),  parse_datetime(b"20010203T04:05:06+0700"));
-    assert_eq!(parse_datetime(b"2001-02-03T04:05:00+07:00"),  parse_datetime(b"20010203T0405+0700"));
-    assert_eq!(parse_datetime(b"20010203T0405+0700"),         parse_datetime(b"2001-02-03T0405+0700"));
-    assert_eq!(parse_datetime(b"20010203T040506+0700"),       parse_datetime(b"2001-02-03T040506+0700"));
-    assert_eq!(parse_datetime(b"20010203T040506+0000"),       parse_datetime(b"20010203T040506Z"));
-    assert_eq!(parse_datetime(b"2015W056T04:05:06+07:00"),    parse_datetime(b"2015-W05-6T04:05:06+07:00"));
+    assert_eq!(parse_datetime(Input(b"2001-02-03T04:05:06+07:00")),  parse_datetime(Input(b"20010203T040506+0700")));
+    assert_eq!(parse_datetime(Input(b"2001-02-03T04:05:06+07:00")),  parse_datetime(Input(b"20010203T04:05:06+0700")));
+    assert_eq!(parse_datetime(Input(b"2001-02-03T04:05:00+07:00")),  parse_datetime(Input(b"20010203T0405+0700")));
+    assert_eq!(parse_datetime(Input(b"20010203T0405+0700")),         parse_datetime(Input(b"2001-02-03T0405+0700")));
+    assert_eq!(parse_datetime(Input(b"20010203T040506+0700")),       parse_datetime(Input(b"2001-02-03T040506+0700")));
+    assert_eq!(parse_datetime(Input(b"20010203T040506+0000")),       parse_datetime(Input(b"20010203T040506Z")));
+    assert_eq!(parse_datetime(Input(b"2015W056T04:05:06+07:00")),    parse_datetime(Input(b"2015-W05-6T04:05:06+07:00")));
 }
 
 #[test]
 fn test_datetime_correct() {
-    assert_eq!(parse_datetime(b"20060831T16:44+00:00"),       Ok((&[][..], DateTime{ date: Date::YMD    { year: 2006,  month:08,  day:31},  time: Time{ hour: 16,  minute:44,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2007-08-31T16:45+00:00"),     Ok((&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:45,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"20070831T1646+00:00"),        Ok((&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:46,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"20070831T1647+0000"),         Ok((&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:47,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2009-02-01T09:00:22+05"),     Ok((&[][..], DateTime{ date: Date::YMD    { year: 2009,  month:02,  day:01},  time: Time{ hour: 9,   minute:0,   second:22,  millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2010-01-01T12:00:00+01:00"),  Ok((&[][..], DateTime{ date: Date::YMD    { year: 2010,  month:1,   day:1},   time: Time{ hour: 12,  minute:0,   second:0,   millisecond: 0, tz_offset_hours: 1, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2011-06-30T18:30:00+02:00"),  Ok((&[][..], DateTime{ date: Date::YMD    { year: 2011,  month:06,  day:30},  time: Time{ hour: 18,  minute:30,  second:0,   millisecond: 0, tz_offset_hours: 2, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015-06-29T23:07+02:00"),     Ok((&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:29},  time: Time{ hour: 23,  minute:07,  second:0,   millisecond: 0, tz_offset_hours: 2, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015-06-26T16:43:16"),        Ok((&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:26},  time: Time{ hour: 16,  minute:43,  second:16,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015-06-26T16:43:16"),        Ok((&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:26},  time: Time{ hour: 16,  minute:43,  second:16,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015-W05-6T04:05:06+07:00"),  Ok((&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:05,     d:6},     time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015W056T04:05:06+07:00"),    Ok((&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:05,     d:6},     time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015-056T04:05:06+07:00"),    Ok((&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:56},             time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015056T04:05:06+07:00"),     Ok((&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:56},             time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015-297T16:30:48Z"),         Ok((&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:297},            time: Time{ hour: 16,  minute:30,  second:48,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2015-W43-6T16:30:48Z"),       Ok((&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:43,     d:6},     time: Time{ hour: 16,  minute:30,  second:48,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2001-W05-6T04:05:06.1234Z"),  Ok((&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})));
-    assert_eq!(parse_datetime(b"2001-W05-6T04:05:06.12345Z"), Ok((&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"20060831T16:44+00:00")),       Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2006,  month:08,  day:31},  time: Time{ hour: 16,  minute:44,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2007-08-31T16:45+00:00")),     Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:45,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"20070831T1646+00:00")),        Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:46,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"20070831T1647+0000")),         Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:47,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2009-02-01T09:00:22+05")),     Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2009,  month:02,  day:01},  time: Time{ hour: 9,   minute:0,   second:22,  millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2010-01-01T12:00:00+01:00")),  Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2010,  month:1,   day:1},   time: Time{ hour: 12,  minute:0,   second:0,   millisecond: 0, tz_offset_hours: 1, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2011-06-30T18:30:00+02:00")),  Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2011,  month:06,  day:30},  time: Time{ hour: 18,  minute:30,  second:0,   millisecond: 0, tz_offset_hours: 2, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015-06-29T23:07+02:00")),     Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:29},  time: Time{ hour: 23,  minute:07,  second:0,   millisecond: 0, tz_offset_hours: 2, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015-06-26T16:43:16")),        Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:26},  time: Time{ hour: 16,  minute:43,  second:16,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015-06-26T16:43:16")),        Ok((Input(&[][..]), DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:26},  time: Time{ hour: 16,  minute:43,  second:16,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015-W05-6T04:05:06+07:00")),  Ok((Input(&[][..]), DateTime{ date: Date::Week   { year: 2015,  ww:05,     d:6},     time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015W056T04:05:06+07:00")),    Ok((Input(&[][..]), DateTime{ date: Date::Week   { year: 2015,  ww:05,     d:6},     time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015-056T04:05:06+07:00")),    Ok((Input(&[][..]), DateTime{ date: Date::Ordinal{ year: 2015,  ddd:56},             time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015056T04:05:06+07:00")),     Ok((Input(&[][..]), DateTime{ date: Date::Ordinal{ year: 2015,  ddd:56},             time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015-297T16:30:48Z")),         Ok((Input(&[][..]), DateTime{ date: Date::Ordinal{ year: 2015,  ddd:297},            time: Time{ hour: 16,  minute:30,  second:48,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2015-W43-6T16:30:48Z")),       Ok((Input(&[][..]), DateTime{ date: Date::Week   { year: 2015,  ww:43,     d:6},     time: Time{ hour: 16,  minute:30,  second:48,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2001-W05-6T04:05:06.1234Z")),  Ok((Input(&[][..]), DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(Input(b"2001-W05-6T04:05:06.12345Z")), Ok((Input(&[][..]), DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})));
 }
 
 #[test]
@@ -226,28 +232,28 @@ fn test_datetime_error() {
     let test_datetimes = vec!["ppp", "dumd-di-duTmd:iu:m"];
 
     for iso_string in test_datetimes {
-        let res = parse_datetime(iso_string.as_bytes());
+        let res = parse_datetime(Input(iso_string.as_bytes()));
         assert!(res.is_err());
     }
 }
 
 #[test]
 fn disallows_notallowed() {
-    assert!(parse_time(b"30:90:90").is_err());
-    assert!(parse_date(b"0000-20-40").is_err());
-    assert!(parse_datetime(b"2001-w05-6t04:05:06.123z").is_err());
+    assert!(parse_time(Input(b"30:90:90")).is_err());
+    assert!(parse_date(Input(b"0000-20-40")).is_err());
+    assert!(parse_datetime(Input(b"2001-w05-6t04:05:06.123z")).is_err());
 }
 
 // #[test]
 // fn corner_cases() {
 //    // how to deal with left overs?
-//    assert!(parse_datetime(b"2015-06-26T22:57:09Z00:00").is_done());
+//    assert!(parse_datetime(Input(b"2015-06-26T22:57:09Z00:00").is_done());
 //    assert!(date("2015-06-26T22:57:09Z00:00").is_err());
 //
-//    assert!(parse_datetime(b"2015-06-26T22:57:09Z+00:00").is_done());
+//    assert!(parse_datetime(Input(b"2015-06-26T22:57:09Z+00:00").is_done());
 //    assert!(datetime("2015-06-26T22:57:09Z+00:00").is_err());
-//    assert!(parse_datetime(b"2001-W05-6T04:05:06.123455Z").is_err());
-//    assert!(parse_datetime(b"2015-06-26TZ").is_err());
+//    assert!(parse_datetime(Input(b"2001-W05-6T04:05:06.123455Z").is_err());
+//    assert!(parse_datetime(Input(b"2015-06-26TZ").is_err());
 // }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,55 +3,53 @@
 extern crate iso8601;
 extern crate nom;
 
-use nom::IResult::*;
-
 use iso8601::*;
 use iso8601::parsers::*;
 
 
 #[test]
 fn test_date() {
-    assert_eq!(Done(&[][..], Date::YMD { year: 2015, month: 6, day: 26, }), parse_date(b"2015-06-26"));
-    assert_eq!(Done(&[][..], Date::YMD { year: -333, month: 7, day: 11, }), parse_date(b"-0333-07-11"));
+    assert_eq!(Ok((&[][..], Date::YMD { year: 2015, month: 6, day: 26, })), parse_date(b"2015-06-26"));
+    assert_eq!(Ok((&[][..], Date::YMD { year: -333, month: 7, day: 11, })), parse_date(b"-0333-07-11"));
 
-    assert!(parse_date(b"201").is_incomplete());
+    assert!(parse_date(b"201").unwrap_err().is_incomplete());
     assert!(parse_date(b"2015p00p00").is_err());
     assert!(parse_date(b"pppp").is_err());
 }
 
 #[test]
 fn test_millisecond() {
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 100,    tz_offset_hours: 0, tz_offset_minutes: 0}), parse_time(b"16:43:00.1"));
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 120,   tz_offset_hours: 0, tz_offset_minutes: 0}), parse_time(b"16:43:00.12"));
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 123,  tz_offset_hours: 0, tz_offset_minutes: 0}), parse_time(b"16:43:00.123"));
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0}), parse_time(b"16:43:00.4321"));
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0}), parse_time(b"16:43.4321"));
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second: 11,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0}), parse_time(b"16:43:11.4321"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 100,    tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00.1"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 120,   tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00.12"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 123,  tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00.123"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00.4321"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43.4321"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 11,  millisecond: 432, tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:11.4321"));
 
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 100,    tz_offset_hours: 0, tz_offset_minutes: 0}), parse_time(b"16:43:00,1"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second:  0,  millisecond: 100,    tz_offset_hours: 0, tz_offset_minutes: 0})), parse_time(b"16:43:00,1"));
 
     assert_eq!(
-        Done(&[][..],  Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}),
+        Ok((&[][..],  Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),
         parse_time(b"04:05:06.12345")
         );
 
     assert_eq!(
-        Done(&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}}),
+        Ok((&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})),
         parse_datetime(b"2001-W05-6T04:05:06.12345Z")
         );
 
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}),  parse_time(b"16:43:16.123"));
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}),  parse_time(b"16:43:16.123+00:00"));
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}),  parse_time(b"16:43:16.123-00:00"));
-    assert_eq!(Done(&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 5, tz_offset_minutes: 0}),  parse_time(b"16:43:16.123+05:00"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(b"16:43:16.123"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(b"16:43:16.123+00:00"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0})),  parse_time(b"16:43:16.123-00:00"));
+    assert_eq!(Ok((&[][..], Time{ hour: 16, minute: 43, second: 16,  millisecond: 123, tz_offset_hours: 5, tz_offset_minutes: 0})),  parse_time(b"16:43:16.123+05:00"));
 }
 
 #[test]
 fn test_time() {
-    assert_eq!(parse_time(b"16:43:16"), Done(&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }) );
-    assert_eq!(parse_time(b"16:43"),    Done(&[][..], Time { hour: 16, minute: 43, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }) );
+    assert_eq!(parse_time(b"16:43:16"), Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })) );
+    assert_eq!(parse_time(b"16:43"),    Ok((&[][..], Time { hour: 16, minute: 43, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })) );
 
-    assert!(parse_time(b"20:").is_incomplete());
+    assert!(parse_time(b"20:").unwrap_err().is_incomplete());
     assert!(parse_time(b"20p42p16").is_err());
     assert!(parse_time(b"pppp").is_err());
 }
@@ -80,54 +78,54 @@ fn test_time_set_tz() {
 
 #[test]
 fn short_time1() {
-    assert_eq!(parse_time(b"1648"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"1648"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time2() {
-    assert_eq!(parse_time(b"16:48"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"16:48"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time3() {
-    assert_eq!(parse_time(b"16:48Z"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"16:48Z"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time4() {
-    assert_eq!(parse_time(b"164800"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"164800"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time5() {
-    assert_eq!(parse_time(b"164800.1"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 100, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"164800.1"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 100, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time6() {
-    assert_eq!(parse_time(b"164800.1Z"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 100, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"164800.1Z"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 100, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_time7() {
-    assert_eq!(parse_time(b"16:48:00"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"16:48:00"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 
 #[test]
 fn short_twtz1() {
-    assert_eq!(parse_time(b"1648Z"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"1648Z"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 #[test]
 fn short_twtz2() {
-    assert_eq!(parse_time(b"16:48Z"), Done(&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }));
+    assert_eq!(parse_time(b"16:48Z"), Ok((&[][..], Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })));
 }
 
 #[test]
 fn short_dtim1() {
-    assert_eq!(parse_datetime(b"20070831T1648"), Done(&[][..], DateTime { date: Date::YMD { year: 2007, month: 08, day: 31, }, time: Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, } }));
+    assert_eq!(parse_datetime(b"20070831T1648"), Ok((&[][..], DateTime { date: Date::YMD { year: 2007, month: 08, day: 31, }, time: Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, } })));
 }
 #[test]
 fn short_dtim2() {
-    assert_eq!(parse_datetime(b"20070831T1648Z"), Done(&[][..], DateTime { date: Date::YMD { year: 2007, month: 08, day: 31, }, time: Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }, }));
+    assert_eq!(parse_datetime(b"20070831T1648Z"), Ok((&[][..], DateTime { date: Date::YMD { year: 2007, month: 08, day: 31, }, time: Time { hour: 16, minute: 48, second: 0, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }, })));
 }
 #[test]
 fn short_dtim3() {
     assert_eq!(parse_datetime(b"2008-12-24T18:21Z"),
-               Done(&[][..],
+               Ok((&[][..],
                     DateTime {
                         date: Date::YMD {
                             year: 2008,
@@ -142,32 +140,32 @@ fn short_dtim3() {
                             tz_offset_hours: 0,
                             tz_offset_minutes: 0,
                         },
-                    }));
+                    })));
 }
 
 #[test]
 fn test_time_with_timezone() {
-    assert_eq!(Done(&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }), parse_time(b"16:43:16"));
-    assert_eq!(Done(&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }), parse_time(b"16:43:16Z"));
-    assert_eq!(Done(&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }), parse_time(b"16:43:16+00:00"));
-    assert_eq!(Done(&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }), parse_time(b"16:43:16-00:00"));
-    assert_eq!(Done(&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0, }), parse_time(b"16:43:16+05:00"));
-    assert_eq!(Done(&b"+"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }), parse_time(b"16:43:16+"));
-    assert_eq!(Done(&b"+0"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }), parse_time(b"16:43:16+0"));
-    assert_eq!(Done(&b"+05:"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, }), parse_time(b"16:43:16+05:"));
+    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16"));
+    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16Z"));
+    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16+00:00"));
+    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16-00:00"));
+    assert_eq!(Ok((&[][..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0, })), parse_time(b"16:43:16+05:00"));
+    assert_eq!(Ok((&b"+"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16+"));
+    assert_eq!(Ok((&b"+0"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16+0"));
+    assert_eq!(Ok((&b"+05:"[..], Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0, })), parse_time(b"16:43:16+05:"));
 
-    assert!(parse_time(b"20:").is_incomplete());
+    assert!(parse_time(b"20:").unwrap_err().is_incomplete());
     assert!(parse_time(b"20p42p16").is_err());
     assert!(parse_time(b"pppp").is_err());
 }
 
 #[test]
 fn test_iso_week_date() {
-    assert_eq!(Done(&[][..], Date::Week { year: 2015, ww: 5, d: 7, }), iso_week_date(b"2015-W05-7"));
-    assert_eq!(Done(&[][..], Date::Week { year: 2015, ww: 6, d: 6, }), iso_week_date(b"2015-W06-6"));
-    assert_eq!(Done(&[][..], Date::Week { year: 2015, ww: 6, d: 6, }), iso_week_date(b"2015-W066"));
-    assert_eq!(Done(&[][..], Date::Week { year: 2015, ww: 6, d: 6, }), iso_week_date(b"2015W066"));
-    assert_eq!(Done(&[][..], Date::Week { year: 2015, ww: 43, d: 6, }), iso_week_date(b"2015-W43-6"));
+    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 5, d: 7, })), iso_week_date(b"2015-W05-7"));
+    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(b"2015-W06-6"));
+    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(b"2015-W066"));
+    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 6, d: 6, })), iso_week_date(b"2015W066"));
+    assert_eq!(Ok((&[][..], Date::Week { year: 2015, ww: 43, d: 6, })), iso_week_date(b"2015-W43-6"));
 
     assert!(iso_week_date(b"2015-W06-8").is_err());
     assert!(iso_week_date(b"2015-W068").is_err());
@@ -179,12 +177,12 @@ fn test_iso_week_date() {
 
 #[test]
 fn test_ordinal_date() {
-    assert_eq!(Done(&[][..], Date::Ordinal { year: 2015, ddd: 57, }),  ordinal_date(b"2015-057"));
+    assert_eq!(Ok((&[][..], Date::Ordinal { year: 2015, ddd: 57, })),  ordinal_date(b"2015-057"));
 
     // not valid, but this should be tested elsewhere
-    assert_eq!(Done(&[][..], Date::Ordinal { year: 2015, ddd: 358, }), ordinal_date(b"2015-358"));
-    assert_eq!(Done(&[][..], Date::Ordinal { year: 2015, ddd: 399, }), ordinal_date(b"2015-399"));
-    assert_eq!(Done(&[][..], Date::Ordinal { year: 2015, ddd: 000, }), ordinal_date(b"2015-000"));
+    assert_eq!(Ok((&[][..], Date::Ordinal { year: 2015, ddd: 358, })), ordinal_date(b"2015-358"));
+    assert_eq!(Ok((&[][..], Date::Ordinal { year: 2015, ddd: 399, })), ordinal_date(b"2015-399"));
+    assert_eq!(Ok((&[][..], Date::Ordinal { year: 2015, ddd: 000, })), ordinal_date(b"2015-000"));
 
     // not valid here either
     assert!(ordinal_date(b"2015-400").is_err());
@@ -203,24 +201,24 @@ fn format_equivalence() {
 
 #[test]
 fn test_datetime_correct() {
-    assert_eq!(parse_datetime(b"20060831T16:44+00:00"),       Done(&[][..], DateTime{ date: Date::YMD    { year: 2006,  month:08,  day:31},  time: Time{ hour: 16,  minute:44,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2007-08-31T16:45+00:00"),     Done(&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:45,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"20070831T1646+00:00"),        Done(&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:46,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"20070831T1647+0000"),         Done(&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:47,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2009-02-01T09:00:22+05"),     Done(&[][..], DateTime{ date: Date::YMD    { year: 2009,  month:02,  day:01},  time: Time{ hour: 9,   minute:0,   second:22,  millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2010-01-01T12:00:00+01:00"),  Done(&[][..], DateTime{ date: Date::YMD    { year: 2010,  month:1,   day:1},   time: Time{ hour: 12,  minute:0,   second:0,   millisecond: 0, tz_offset_hours: 1, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2011-06-30T18:30:00+02:00"),  Done(&[][..], DateTime{ date: Date::YMD    { year: 2011,  month:06,  day:30},  time: Time{ hour: 18,  minute:30,  second:0,   millisecond: 0, tz_offset_hours: 2, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015-06-29T23:07+02:00"),     Done(&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:29},  time: Time{ hour: 23,  minute:07,  second:0,   millisecond: 0, tz_offset_hours: 2, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015-06-26T16:43:16"),        Done(&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:26},  time: Time{ hour: 16,  minute:43,  second:16,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015-06-26T16:43:16"),        Done(&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:26},  time: Time{ hour: 16,  minute:43,  second:16,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015-W05-6T04:05:06+07:00"),  Done(&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:05,     d:6},     time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015W056T04:05:06+07:00"),    Done(&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:05,     d:6},     time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015-056T04:05:06+07:00"),    Done(&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:56},             time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015056T04:05:06+07:00"),     Done(&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:56},             time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015-297T16:30:48Z"),         Done(&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:297},            time: Time{ hour: 16,  minute:30,  second:48,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2015-W43-6T16:30:48Z"),       Done(&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:43,     d:6},     time: Time{ hour: 16,  minute:30,  second:48,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2001-W05-6T04:05:06.1234Z"),  Done(&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}}));
-    assert_eq!(parse_datetime(b"2001-W05-6T04:05:06.12345Z"), Done(&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}}));
+    assert_eq!(parse_datetime(b"20060831T16:44+00:00"),       Ok((&[][..], DateTime{ date: Date::YMD    { year: 2006,  month:08,  day:31},  time: Time{ hour: 16,  minute:44,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2007-08-31T16:45+00:00"),     Ok((&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:45,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"20070831T1646+00:00"),        Ok((&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:46,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"20070831T1647+0000"),         Ok((&[][..], DateTime{ date: Date::YMD    { year: 2007,  month:08,  day:31},  time: Time{ hour: 16,  minute:47,  second:0,   millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2009-02-01T09:00:22+05"),     Ok((&[][..], DateTime{ date: Date::YMD    { year: 2009,  month:02,  day:01},  time: Time{ hour: 9,   minute:0,   second:22,  millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2010-01-01T12:00:00+01:00"),  Ok((&[][..], DateTime{ date: Date::YMD    { year: 2010,  month:1,   day:1},   time: Time{ hour: 12,  minute:0,   second:0,   millisecond: 0, tz_offset_hours: 1, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2011-06-30T18:30:00+02:00"),  Ok((&[][..], DateTime{ date: Date::YMD    { year: 2011,  month:06,  day:30},  time: Time{ hour: 18,  minute:30,  second:0,   millisecond: 0, tz_offset_hours: 2, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015-06-29T23:07+02:00"),     Ok((&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:29},  time: Time{ hour: 23,  minute:07,  second:0,   millisecond: 0, tz_offset_hours: 2, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015-06-26T16:43:16"),        Ok((&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:26},  time: Time{ hour: 16,  minute:43,  second:16,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015-06-26T16:43:16"),        Ok((&[][..], DateTime{ date: Date::YMD    { year: 2015,  month:06,  day:26},  time: Time{ hour: 16,  minute:43,  second:16,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015-W05-6T04:05:06+07:00"),  Ok((&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:05,     d:6},     time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015W056T04:05:06+07:00"),    Ok((&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:05,     d:6},     time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015-056T04:05:06+07:00"),    Ok((&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:56},             time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015056T04:05:06+07:00"),     Ok((&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:56},             time: Time{ hour: 04,  minute:5,   second:6,   millisecond: 0, tz_offset_hours: 7, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015-297T16:30:48Z"),         Ok((&[][..], DateTime{ date: Date::Ordinal{ year: 2015,  ddd:297},            time: Time{ hour: 16,  minute:30,  second:48,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2015-W43-6T16:30:48Z"),       Ok((&[][..], DateTime{ date: Date::Week   { year: 2015,  ww:43,     d:6},     time: Time{ hour: 16,  minute:30,  second:48,  millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2001-W05-6T04:05:06.1234Z"),  Ok((&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})));
+    assert_eq!(parse_datetime(b"2001-W05-6T04:05:06.12345Z"), Ok((&[][..], DateTime{ date: Date::Week   { year: 2001,  ww:05,     d:6},     time: Time{ hour: 04,  minute:05,  second:06,  millisecond: 123, tz_offset_hours: 0, tz_offset_minutes: 0}})));
 }
 
 #[test]
@@ -229,7 +227,7 @@ fn test_datetime_error() {
 
     for iso_string in test_datetimes {
         let res = parse_datetime(iso_string.as_bytes());
-        assert!(res.is_err() || res.is_incomplete());
+        assert!(res.is_err());
     }
 }
 


### PR DESCRIPTION
Hello,

I'm currently testing the upgrade to nom 4 on various crates, to see if I forgot anything. Currently, I get this error after doing the following changes:

```

failures:

---- test_time_with_timezone stdout ----
        thread 'test_time_with_timezone' panicked at 'assertion failed: `(left == right)`
  left: `Ok((CompleteByteSlice([43, 48, 53, 58]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 0, tz_offset_minutes: 0 }))`,
 right: `Ok((CompleteByteSlice([58]), Time { hour: 16, minute: 43, second: 16, millisecond: 0, tz_offset_hours: 5, tz_offset_minutes: 0 }))`', tests/lib.rs:161:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.


failures:
    test_time_with_timezone

test result: FAILED. 24 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

The most notable change is the introduction of the `CompleteByteSlice` type, which removes all `Incomplete` usage, assuming the input is complete. See [the upgrade doc](https://github.com/Geal/nom/blob/master/doc/upgrading_to_nom_4.md#dealing-with-incomplete-usage) for more information.