### PR TITLE
Added support for ISO 8601 Durations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,11 +208,11 @@ pub fn datetime(string: &str) -> Result<DateTime, String> {
 /// The weekly interval format gets parsed into the Weeks Duration variant.
 ///
 /// The ranges for each of the individual units are not expected to exceed
-/// the next largest unit, with the year not expected to exceed four digits.
+/// the next largest unit.
 ///
 /// These ranges (inclusive) are as follows:
 ///
-/// * Year 0 - 9999
+/// * Year (any valid u32)
 /// * Month 0 - 12
 /// * Week 0 - 52
 /// * Day 0 - 31

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub struct DateTime {
     pub time: Time,
 }
 
-/// A duration, can hold three different formats.
+/// A time duration.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum Duration {
     /// consists of year, month, day, hour, minute and second units
@@ -67,8 +67,6 @@ pub enum Duration {
     },
     /// consists of week units
     Weeks(u32),
-    /// consists of an ISO 8601 format [DateTime](struct.DateTime.html)
-    DateTime(DateTime),
 }
 
 impl Time {
@@ -202,9 +200,12 @@ pub fn datetime(string: &str) -> Result<DateTime, String> {
 ///
 /// A string starts with `P` and can have one of the following formats:
 ///
-/// * `P1Y2M3DT4H5M6S`
-/// * `P1W`
-/// * `P<datetime>`
+/// * Fully-specified duration: `P1Y2M3DT4H5M6S`
+/// * Duration in weekly intervals: `P1W`
+/// * Fully-specified duration in [DateTime](struct.DateTime.html) format: `P<datetime>`
+///
+/// Both fully-specified formats get parsed into the YMDHMS Duration variant.
+/// The weekly interval format gets parsed into the Weeks Duration variant.
 ///
 /// The ranges for each of the individual units are not expected to exceed
 /// the next largest unit, with the year not expected to exceed four digits.

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -15,15 +15,17 @@ use nom::{
     bytes::complete::{tag, take_while, take_while_m_n},
     character::complete::one_of,
     character::is_digit,
-    combinator::{map, opt},
-    sequence::preceded,
+    combinator::{map, not, opt},
+    sequence::{preceded, terminated},
     IResult,
 };
 
-use crate::{Date, DateTime, Time};
+use crate::{Date, DateTime, Duration, Time};
 
 #[cfg(test)]
 mod tests;
+
+// UTILITY
 
 fn take_n_digits(i: &[u8], n: usize) -> IResult<&[u8], u32> {
     let (i, digits) = take_while_m_n(n, n, is_digit)(i)?;
@@ -31,25 +33,20 @@ fn take_n_digits(i: &[u8], n: usize) -> IResult<&[u8], u32> {
     let s = str::from_utf8(digits).expect("Invalid data, expected UTF-8 string");
     let res = s
         .parse()
-        .expect("Invalid string, expected ASCII reprensation of a number");
+        .expect("Invalid string, expected ASCII reprensentation of a number");
+
     Ok((i, res))
 }
 
-fn sign(i: &[u8]) -> IResult<&[u8], i32> {
-    map(alt((tag(b"-"), tag(b"+"))), |s: &[u8]| match s {
-        b"-" => -1,
-        _ => 1,
-    })(i)
-}
+fn take_m_to_n_digits(i: &[u8], m: usize, n: usize) -> IResult<&[u8], u32> {
+    let (i, digits) = take_while_m_n(m, n, is_digit)(i)?;
 
-// [+/-] year
-fn year(i: &[u8]) -> IResult<&[u8], i32> {
-    // The sign is optional, but defaults to `+`
-    let (i, s) = sign(i).unwrap_or((i, 1));
-    let (i, year) = take_n_digits(i, 4)?;
-    let year = s * year as i32;
+    let s = str::from_utf8(digits).expect("Invalid data, expected UTF-8 string");
+    let res = s
+        .parse()
+        .expect("Invalid string, expected ASCII representation of a number");
 
-    Ok((i, year))
+    Ok((i, res))
 }
 
 fn n_digit_in_range(
@@ -66,37 +63,80 @@ fn n_digit_in_range(
     }
 }
 
+fn m_to_n_digit_in_range(
+    i: &[u8],
+    m: usize,
+    n: usize,
+    range: impl std::ops::RangeBounds<u32>,
+) -> IResult<&[u8], u32> {
+    let (new_i, number) = take_m_to_n_digits(i, m, n)?;
+
+    if range.contains(&number) {
+        Ok((new_i, number))
+    } else {
+        Err(nom::Err::Error((i, nom::error::ErrorKind::Eof)))
+    }
+}
+
+fn sign(i: &[u8]) -> IResult<&[u8], i32> {
+    map(alt((tag(b"-"), tag(b"+"))), |s: &[u8]| match s {
+        b"-" => -1,
+        _ => 1,
+    })(i)
+}
+
+fn fractions(i: &[u8]) -> IResult<&[u8], f32> {
+    let (i, digits) = take_while(is_digit)(i)?;
+    let digits = str::from_utf8(digits).unwrap(); // This can't panic, `digits` will only include digits.
+    let f = format!("0.{}", digits).parse().unwrap(); // This can't panic, the string is a valid `f32`.
+
+    Ok((i, f))
+}
+
+// DATE
+
+// [+/-]YYYY
+fn date_year(i: &[u8]) -> IResult<&[u8], i32> {
+    // The sign is optional, but defaults to `+`
+    let (i, s) = sign(i).unwrap_or((i, 1));
+    let (i, year) = take_n_digits(i, 4)?;
+    let year = s * year as i32;
+
+    Ok((i, year))
+}
+
 // MM
-fn month(i: &[u8]) -> IResult<&[u8], u32> {
+fn date_month(i: &[u8]) -> IResult<&[u8], u32> {
     n_digit_in_range(i, 2, 1..=12)
 }
 
 // DD
-fn day(i: &[u8]) -> IResult<&[u8], u32> {
+fn date_day(i: &[u8]) -> IResult<&[u8], u32> {
     n_digit_in_range(i, 2, 1..=31)
 }
 
 // WW
-fn week(i: &[u8]) -> IResult<&[u8], u32> {
+fn date_week(i: &[u8]) -> IResult<&[u8], u32> {
     n_digit_in_range(i, 2, 1..=52)
 }
 
-fn week_day(i: &[u8]) -> IResult<&[u8], u32> {
+fn date_week_day(i: &[u8]) -> IResult<&[u8], u32> {
     n_digit_in_range(i, 1, 1..=7)
 }
 
 // ordinal DDD
-fn ord_day(i: &[u8]) -> IResult<&[u8], u32> {
+fn date_ord_day(i: &[u8]) -> IResult<&[u8], u32> {
     n_digit_in_range(i, 3, 1..=366)
 }
 
 // YYYY-MM-DD
-fn ymd_date(i: &[u8]) -> IResult<&[u8], Date> {
-    let (i, y) = year(i)?;
+fn date_ymd(i: &[u8]) -> IResult<&[u8], Date> {
+    let (i, y) = date_year(i)?;
     let (i, _) = opt(tag(b"-"))(i)?;
-    let (i, m) = month(i)?;
+    let (i, m) = date_month(i)?;
     let (i, _) = opt(tag(b"-"))(i)?;
-    let (i, d) = day(i)?;
+    let (i, d) = date_day(i)?;
+
     Ok((
         i,
         Date::YMD {
@@ -108,21 +148,23 @@ fn ymd_date(i: &[u8]) -> IResult<&[u8], Date> {
 }
 
 // YYYY-DDD
-fn ordinal_date(i: &[u8]) -> IResult<&[u8], Date> {
-    let (i, y) = year(i)?;
+fn date_ordinal(i: &[u8]) -> IResult<&[u8], Date> {
+    let (i, y) = date_year(i)?;
     let (i, _) = opt(tag(b"-"))(i)?;
-    let (i, d) = ord_day(i)?;
+    let (i, d) = date_ord_day(i)?;
+
     Ok((i, Date::Ordinal { year: y, ddd: d }))
 }
 
 // YYYY-"W"WW-D
-fn iso_week_date(i: &[u8]) -> IResult<&[u8], Date> {
-    let (i, y) = year(i)?;
+fn date_iso_week(i: &[u8]) -> IResult<&[u8], Date> {
+    let (i, y) = date_year(i)?;
     let (i, _) = opt(tag(b"-"))(i)?;
     let (i, _) = tag(b"W")(i)?;
-    let (i, w) = week(i)?;
+    let (i, w) = date_week(i)?;
     let (i, _) = opt(tag(b"-"))(i)?;
-    let (i, d) = week_day(i)?;
+    let (i, d) = date_week_day(i)?;
+
     Ok((
         i,
         Date::Week {
@@ -134,44 +176,37 @@ fn iso_week_date(i: &[u8]) -> IResult<&[u8], Date> {
 }
 
 pub fn parse_date(i: &[u8]) -> IResult<&[u8], Date> {
-    alt((ymd_date, iso_week_date, ordinal_date))(i)
+    alt((date_ymd, date_iso_week, date_ordinal))(i)
 }
 
 // TIME
 
 // HH
-fn hour(i: &[u8]) -> IResult<&[u8], u32> {
+fn time_hour(i: &[u8]) -> IResult<&[u8], u32> {
     n_digit_in_range(i, 2, 0..=24)
 }
 
 // MM
-fn minute(i: &[u8]) -> IResult<&[u8], u32> {
+fn time_minute(i: &[u8]) -> IResult<&[u8], u32> {
     n_digit_in_range(i, 2, 0..=59)
 }
 
-fn second(i: &[u8]) -> IResult<&[u8], u32> {
+// SS
+fn time_second(i: &[u8]) -> IResult<&[u8], u32> {
     n_digit_in_range(i, 2, 0..=60)
 }
 
-fn fractions(i: &[u8]) -> IResult<&[u8], f32> {
-    let (i, digits) = take_while(is_digit)(i)?;
-    let digits = str::from_utf8(digits).unwrap(); // This can't panic, `digits` will only include digits.
-    let f = format!("0.{}", digits).parse().unwrap(); // This can't panic, the string is a valid `f32`.
-
-    Ok((i, f))
-}
-
-fn millisecond(fraction: f32) -> u32 {
+fn time_millisecond(fraction: f32) -> u32 {
     (1000.0 * fraction) as u32
 }
 
 // HH:MM:[SS][.(m*)][(Z|+...|-...)]
 pub fn parse_time(i: &[u8]) -> IResult<&[u8], Time> {
-    let (i, h) = hour(i)?;
+    let (i, h) = time_hour(i)?;
     let (i, _) = opt(tag(b":"))(i)?;
-    let (i, m) = minute(i)?;
-    let (i, s) = opt(preceded(opt(tag(b":")), second))(i)?;
-    let (i, ms) = opt(map(preceded(one_of(",."), fractions), millisecond))(i)?;
+    let (i, m) = time_minute(i)?;
+    let (i, s) = opt(preceded(opt(tag(b":")), time_second))(i)?;
+    let (i, ms) = opt(map(preceded(one_of(",."), fractions), time_millisecond))(i)?;
     let (i, z) = match opt(alt((timezone_hour, timezone_utc)))(i) {
         Ok(ok) => ok,
         Err(nom::Err::Incomplete(_)) => (i, None),
@@ -195,12 +230,12 @@ pub fn parse_time(i: &[u8]) -> IResult<&[u8], Time> {
 
 fn timezone_hour(i: &[u8]) -> IResult<&[u8], (i32, i32)> {
     let (i, s) = sign(i)?;
-    let (i, h) = hour(i)?;
+    let (i, h) = time_hour(i)?;
     let (i, m) = if i.is_empty() {
         (i, 0)
     } else {
         let (i, _) = opt(tag(b":"))(i)?;
-        minute(i)?
+        time_minute(i)?
     };
 
     Ok((i, ((s * (h as i32), s * (m as i32)))))
@@ -210,11 +245,111 @@ fn timezone_utc(i: &[u8]) -> IResult<&[u8], (i32, i32)> {
     map(tag(b"Z"), |_| (0, 0))(i)
 }
 
-// Full ISO8601
+// Full ISO8601 datetime
 pub fn parse_datetime(i: &[u8]) -> IResult<&[u8], DateTime> {
     let (i, d) = parse_date(i)?;
     let (i, _) = tag(b"T")(i)?;
     let (i, t) = parse_time(i)?;
 
     Ok((i, DateTime { date: d, time: t }))
+}
+
+// DURATION
+
+// Y[YYY]
+fn duration_year(i: &[u8]) -> IResult<&[u8], u32> {
+    m_to_n_digit_in_range(i, 1, 4, 0..=9999)
+}
+
+// M[M]
+fn duration_month(i: &[u8]) -> IResult<&[u8], u32> {
+    m_to_n_digit_in_range(i, 1, 2, 0..=12)
+}
+
+// W[W]
+fn duration_week(i: &[u8]) -> IResult<&[u8], u32> {
+    m_to_n_digit_in_range(i, 1, 2, 0..=52)
+}
+
+// D[D]
+fn duration_day(i: &[u8]) -> IResult<&[u8], u32> {
+    m_to_n_digit_in_range(i, 1, 2, 0..=31)
+}
+
+// H[H]
+fn duration_hour(i: &[u8]) -> IResult<&[u8], u32> {
+    m_to_n_digit_in_range(i, 1, 2, 0..=24)
+}
+
+// M[M]
+fn duration_minute(i: &[u8]) -> IResult<&[u8], u32> {
+    m_to_n_digit_in_range(i, 1, 2, 0..=60)
+}
+
+// S[S][[,.][MS]]
+fn duration_second_and_millisecond(i: &[u8]) -> IResult<&[u8], (u32, u32)> {
+    let (i, s) = m_to_n_digit_in_range(i, 1, 2, 0..=60)?;
+    let (i, ms) = opt(map(preceded(one_of(",."), fractions), duration_millisecond))(i)?;
+
+    Ok((i, (s, ms.unwrap_or(0))))
+}
+
+fn duration_millisecond(fraction: f32) -> u32 {
+    (1000.0 * fraction) as u32
+}
+
+fn duration_time(i: &[u8]) -> IResult<&[u8], (u32, u32, u32, u32)> {
+    let (i, h) = opt(terminated(duration_hour, tag(b"H")))(i)?;
+    let (i, m) = opt(terminated(duration_minute, tag(b"M")))(i)?;
+    let (i, s) = opt(terminated(duration_second_and_millisecond, tag(b"S")))(i)?;
+    let (s, ms) = s.unwrap_or((0, 0));
+
+    Ok((i, (h.unwrap_or(0), m.unwrap_or(0), s, ms)))
+}
+
+fn duration_ymdhms(i: &[u8]) -> IResult<&[u8], Duration> {
+    let (i, _) = tag(b"P")(i)?;
+    let (i, y) = opt(terminated(duration_year, tag(b"Y")))(i)?;
+    let (i, mo) = opt(terminated(duration_month, tag(b"M")))(i)?;
+    let (i, d) = opt(terminated(duration_day, tag(b"D")))(i)?;
+    let (i, time) = opt(preceded(tag(b"T"), duration_time))(i)?;
+
+    // at least one element must be present for a valid duration representation
+    if y.is_none() && mo.is_none() && d.is_none() && time.is_none() {
+        return Err(nom::Err::Error((i, nom::error::ErrorKind::Eof)));
+    }
+
+    let (h, mi, s, ms) = time.unwrap_or((0, 0, 0, 0));
+
+    Ok((
+        i,
+        Duration::YMDHMS {
+            year: y.unwrap_or(0),
+            month: mo.unwrap_or(0),
+            day: d.unwrap_or(0),
+            hour: h,
+            minute: mi,
+            second: s,
+            millisecond: ms,
+        },
+    ))
+}
+
+fn duration_weeks(i: &[u8]) -> IResult<&[u8], Duration> {
+    let (i, _) = tag(b"P")(i)?;
+    let (i, w) = terminated(duration_week, tag(b"W"))(i)?;
+
+    Ok((i, Duration::Weeks(w)))
+}
+
+fn duration_datetime(i: &[u8]) -> IResult<&[u8], Duration> {
+    let (i, _) = tag(b"P")(i)?;
+    let (i, _) = not(sign)(i)?;
+    let (i, dt) = parse_datetime(i)?;
+
+    Ok((i, Duration::DateTime(dt)))
+}
+
+pub fn parse_duration(i: &[u8]) -> IResult<&[u8], Duration> {
+    alt((duration_ymdhms, duration_weeks, duration_datetime))(i)
 }

--- a/src/parsers/tests.rs
+++ b/src/parsers/tests.rs
@@ -1,76 +1,76 @@
 use super::*;
 
 #[test]
-fn test_year() {
-    assert_eq!(Ok((&[][..], 2015)), year(b"2015"));
-    assert_eq!(Ok((&[][..], -0333)), year(b"-0333"));
-    assert_eq!(Ok((&b"-"[..], 2015)), year(b"2015-"));
-    assert!(year(b"abcd").is_err());
-    assert!(year(b"2a03").is_err());
+fn test_date_year() {
+    assert_eq!(Ok((&[][..], 2015)), date_year(b"2015"));
+    assert_eq!(Ok((&[][..], -0333)), date_year(b"-0333"));
+    assert_eq!(Ok((&b"-"[..], 2015)), date_year(b"2015-"));
+    assert!(date_year(b"abcd").is_err());
+    assert!(date_year(b"2a03").is_err());
 }
 
 #[test]
-fn test_month() {
-    assert_eq!(Ok((&[][..], 1)), month(b"01"));
-    assert_eq!(Ok((&[][..], 6)), month(b"06"));
-    assert_eq!(Ok((&[][..], 12)), month(b"12"));
-    assert_eq!(Ok((&b"-"[..], 12)), month(b"12-"));
+fn test_date_month() {
+    assert_eq!(Ok((&[][..], 1)), date_month(b"01"));
+    assert_eq!(Ok((&[][..], 6)), date_month(b"06"));
+    assert_eq!(Ok((&[][..], 12)), date_month(b"12"));
+    assert_eq!(Ok((&b"-"[..], 12)), date_month(b"12-"));
 
-    assert!(month(b"13").is_err());
-    assert!(month(b"00").is_err());
+    assert!(date_month(b"13").is_err());
+    assert!(date_month(b"00").is_err());
 }
 
 #[test]
-fn test_day() {
-    assert_eq!(Ok((&[][..], 1)), day(b"01"));
-    assert_eq!(Ok((&[][..], 12)), day(b"12"));
-    assert_eq!(Ok((&[][..], 20)), day(b"20"));
-    assert_eq!(Ok((&[][..], 28)), day(b"28"));
-    assert_eq!(Ok((&[][..], 30)), day(b"30"));
-    assert_eq!(Ok((&[][..], 31)), day(b"31"));
-    assert_eq!(Ok((&b"-"[..], 31)), day(b"31-"));
+fn test_date_day() {
+    assert_eq!(Ok((&[][..], 1)), date_day(b"01"));
+    assert_eq!(Ok((&[][..], 12)), date_day(b"12"));
+    assert_eq!(Ok((&[][..], 20)), date_day(b"20"));
+    assert_eq!(Ok((&[][..], 28)), date_day(b"28"));
+    assert_eq!(Ok((&[][..], 30)), date_day(b"30"));
+    assert_eq!(Ok((&[][..], 31)), date_day(b"31"));
+    assert_eq!(Ok((&b"-"[..], 31)), date_day(b"31-"));
 
-    assert!(day(b"00").is_err());
-    assert!(day(b"32").is_err());
+    assert!(date_day(b"00").is_err());
+    assert!(date_day(b"32").is_err());
 }
 
 #[test]
-fn test_hour() {
-    assert_eq!(Ok((&[][..], 0)), hour(b"00"));
-    assert_eq!(Ok((&[][..], 1)), hour(b"01"));
-    assert_eq!(Ok((&[][..], 6)), hour(b"06"));
-    assert_eq!(Ok((&[][..], 12)), hour(b"12"));
-    assert_eq!(Ok((&[][..], 13)), hour(b"13"));
-    assert_eq!(Ok((&[][..], 20)), hour(b"20"));
-    assert_eq!(Ok((&[][..], 24)), hour(b"24"));
+fn test_time_hour() {
+    assert_eq!(Ok((&[][..], 0)), time_hour(b"00"));
+    assert_eq!(Ok((&[][..], 1)), time_hour(b"01"));
+    assert_eq!(Ok((&[][..], 6)), time_hour(b"06"));
+    assert_eq!(Ok((&[][..], 12)), time_hour(b"12"));
+    assert_eq!(Ok((&[][..], 13)), time_hour(b"13"));
+    assert_eq!(Ok((&[][..], 20)), time_hour(b"20"));
+    assert_eq!(Ok((&[][..], 24)), time_hour(b"24"));
 
-    assert!(hour(b"25").is_err());
-    assert!(hour(b"30").is_err());
-    assert!(hour(b"ab").is_err());
+    assert!(time_hour(b"25").is_err());
+    assert!(time_hour(b"30").is_err());
+    assert!(time_hour(b"ab").is_err());
 }
 
 #[test]
-fn test_minute() {
-    assert_eq!(Ok((&[][..], 0)), minute(b"00"));
-    assert_eq!(Ok((&[][..], 1)), minute(b"01"));
-    assert_eq!(Ok((&[][..], 30)), minute(b"30"));
-    assert_eq!(Ok((&[][..], 59)), minute(b"59"));
+fn test_time_minute() {
+    assert_eq!(Ok((&[][..], 0)), time_minute(b"00"));
+    assert_eq!(Ok((&[][..], 1)), time_minute(b"01"));
+    assert_eq!(Ok((&[][..], 30)), time_minute(b"30"));
+    assert_eq!(Ok((&[][..], 59)), time_minute(b"59"));
 
-    assert!(minute(b"60").is_err());
-    assert!(minute(b"61").is_err());
-    assert!(minute(b"ab").is_err());
+    assert!(time_minute(b"60").is_err());
+    assert!(time_minute(b"61").is_err());
+    assert!(time_minute(b"ab").is_err());
 }
 
 #[test]
-fn test_second() {
-    assert_eq!(Ok((&[][..], 0)), second(b"00"));
-    assert_eq!(Ok((&[][..], 1)), second(b"01"));
-    assert_eq!(Ok((&[][..], 30)), second(b"30"));
-    assert_eq!(Ok((&[][..], 59)), second(b"59"));
-    assert_eq!(Ok((&[][..], 60)), second(b"60"));
+fn test_time_second() {
+    assert_eq!(Ok((&[][..], 0)), time_second(b"00"));
+    assert_eq!(Ok((&[][..], 1)), time_second(b"01"));
+    assert_eq!(Ok((&[][..], 30)), time_second(b"30"));
+    assert_eq!(Ok((&[][..], 59)), time_second(b"59"));
+    assert_eq!(Ok((&[][..], 60)), time_second(b"60"));
 
-    assert!(second(b"61").is_err());
-    assert!(second(b"ab").is_err());
+    assert!(time_second(b"61").is_err());
+    assert!(time_second(b"ab").is_err());
 }
 
 #[test]
@@ -95,19 +95,19 @@ fn test_time_with_timezone() {
 }
 
 #[test]
-fn test_iso_week_date() {
-    assert!(iso_week_date(b"2015-W06-8").is_err());
-    assert!(iso_week_date(b"2015-W068").is_err());
-    assert!(iso_week_date(b"2015-W06-0").is_err());
-    assert!(iso_week_date(b"2015-W00-2").is_err());
-    assert!(iso_week_date(b"2015-W54-2").is_err());
-    assert!(iso_week_date(b"2015-W542").is_err());
+fn test_date_iso_week_date() {
+    assert!(date_iso_week(b"2015-W06-8").is_err());
+    assert!(date_iso_week(b"2015-W068").is_err());
+    assert!(date_iso_week(b"2015-W06-0").is_err());
+    assert!(date_iso_week(b"2015-W00-2").is_err());
+    assert!(date_iso_week(b"2015-W54-2").is_err());
+    assert!(date_iso_week(b"2015-W542").is_err());
 }
 
 #[test]
-fn test_ordinal_date() {
+fn test_date_ordinal_date() {
     // not valid here either
-    assert!(ordinal_date(b"2015-400").is_err());
+    assert!(date_ordinal(b"2015-400").is_err());
 }
 
 #[test]
@@ -157,6 +157,124 @@ fn disallows_notallowed() {
     assert!(parse_time(b"30:90:90").is_err());
     assert!(parse_date(b"0000-20-40").is_err());
     assert!(parse_datetime(b"2001-w05-6t04:05:06.123z").is_err());
+}
+
+#[test]
+fn test_duration_year() {
+    assert_eq!(Ok((&[][..], 2019)), duration_year(b"2019"));
+    assert_eq!(Ok((&[][..], 0)), duration_year(b"0"));
+    assert_eq!(Ok((&[][..], 9999)), duration_year(b"9999"));
+    assert!(duration_year(b"abcd").is_err());
+    assert!(duration_year(b"-1").is_err());
+}
+
+#[test]
+fn test_duration_month() {
+    assert_eq!(Ok((&[][..], 6)), duration_month(b"6"));
+    assert_eq!(Ok((&[][..], 0)), duration_month(b"0"));
+    assert_eq!(Ok((&[][..], 12)), duration_month(b"12"));
+    assert!(duration_month(b"ab").is_err());
+    assert!(duration_month(b"-1").is_err());
+    assert!(duration_month(b"13").is_err());
+}
+
+#[test]
+fn test_duration_week() {
+    assert_eq!(Ok((&[][..], 26)), duration_week(b"26"));
+    assert_eq!(Ok((&[][..], 0)), duration_week(b"0"));
+    assert_eq!(Ok((&[][..], 52)), duration_week(b"52"));
+    assert!(duration_week(b"ab").is_err());
+    assert!(duration_week(b"-1").is_err());
+    assert!(duration_week(b"53").is_err());
+}
+
+#[test]
+fn test_duration_day() {
+    assert_eq!(Ok((&[][..], 16)), duration_day(b"16"));
+    assert_eq!(Ok((&[][..], 0)), duration_day(b"0"));
+    assert_eq!(Ok((&[][..], 31)), duration_day(b"31"));
+    assert!(duration_day(b"ab").is_err());
+    assert!(duration_day(b"-1").is_err());
+    assert!(duration_day(b"32").is_err());
+}
+
+#[test]
+fn test_duration_hour() {
+    assert_eq!(Ok((&[][..], 12)), duration_hour(b"12"));
+    assert_eq!(Ok((&[][..], 0)), duration_hour(b"0"));
+    assert_eq!(Ok((&[][..], 24)), duration_hour(b"24"));
+    assert!(duration_hour(b"ab").is_err());
+    assert!(duration_hour(b"-1").is_err());
+    assert!(duration_hour(b"25").is_err());
+}
+
+#[test]
+fn test_duration_minute() {
+    assert_eq!(Ok((&[][..], 30)), duration_minute(b"30"));
+    assert_eq!(Ok((&[][..], 0)), duration_minute(b"0"));
+    assert_eq!(Ok((&[][..], 60)), duration_minute(b"60"));
+    assert!(duration_minute(b"ab").is_err());
+    assert!(duration_minute(b"-1").is_err());
+    assert!(duration_minute(b"61").is_err());
+}
+
+#[test]
+fn test_duration_second_and_millisecond() {
+    assert_eq!(
+        Ok((&[][..], (30, 0))),
+        duration_second_and_millisecond(b"30")
+    );
+    assert_eq!(Ok((&[][..], (0, 0))), duration_second_and_millisecond(b"0"));
+    assert_eq!(
+        Ok((&[][..], (60, 0))),
+        duration_second_and_millisecond(b"60")
+    );
+    assert_eq!(
+        Ok((&[][..], (1, 230))),
+        duration_second_and_millisecond(b"1,23")
+    );
+    assert_eq!(
+        Ok((&[][..], (1, 230))),
+        duration_second_and_millisecond(b"1.23")
+    );
+    assert!(duration_second_and_millisecond(b"ab").is_err());
+    assert!(duration_second_and_millisecond(b"-1").is_err());
+    assert!(duration_second_and_millisecond(b"61").is_err());
+}
+
+#[test]
+fn test_duration_time() {
+    assert_eq!(Ok((&[][..], (1, 2, 3, 0))), duration_time(b"1H2M3S"));
+    assert_eq!(Ok((&[][..], (1, 0, 3, 0))), duration_time(b"1H3S"));
+    assert_eq!(Ok((&[][..], (0, 2, 0, 0))), duration_time(b"2M"));
+    assert_eq!(Ok((&[][..], (1, 2, 3, 400))), duration_time(b"1H2M3,4S"));
+    assert_eq!(Ok((&[][..], (1, 2, 3, 400))), duration_time(b"1H2M3.4S"));
+    assert_eq!(Ok((&[][..], (0, 0, 0, 123))), duration_time(b"0,123S"));
+    assert_eq!(Ok((&[][..], (0, 0, 0, 123))), duration_time(b"0.123S"));
+}
+
+#[test]
+fn test_duration_ymdhms_error() {
+    assert!(duration_ymdhms(b"").is_err());
+    assert!(duration_ymdhms(b"P").is_err()); // empty duration is not 0 seconds
+    assert!(duration_ymdhms(b"P12345Y").is_err()); // years in range 0..=9999
+    assert!(duration_ymdhms(b"1Y2M3DT4H5M6S").is_err()); // missing P at start
+    assert!(duration_ymdhms(b"T4H5M6S").is_err()); // missing P, required even if no YMD part
+}
+
+#[test]
+fn test_duration_weeks_error() {
+    assert!(duration_weeks(b"").is_err());
+    assert!(duration_weeks(b"P").is_err()); // empty duration is not 0 seconds
+    assert!(duration_weeks(b"P1").is_err()); // missing W after number
+    assert!(duration_weeks(b"PW").is_err()); // missing number
+}
+
+#[test]
+fn test_duration_datetime_error() {
+    assert!(duration_datetime(b"").is_err());
+    assert!(duration_datetime(b"P").is_err()); // empty duration is not 0 seconds
+    assert!(duration_datetime(b"0001-02-03T04:05:06").is_err()); // missing P at start
 }
 
 // #[test]

--- a/src/parsers/tests.rs
+++ b/src/parsers/tests.rs
@@ -163,7 +163,7 @@ fn disallows_notallowed() {
 fn test_duration_year() {
     assert_eq!(Ok((&[][..], 2019)), duration_year(b"2019"));
     assert_eq!(Ok((&[][..], 0)), duration_year(b"0"));
-    assert_eq!(Ok((&[][..], 9999)), duration_year(b"9999"));
+    assert_eq!(Ok((&[][..], 10000)), duration_year(b"10000"));
     assert!(duration_year(b"abcd").is_err());
     assert!(duration_year(b"-1").is_err());
 }
@@ -257,7 +257,6 @@ fn test_duration_time() {
 fn test_duration_ymdhms_error() {
     assert!(duration_ymdhms(b"").is_err());
     assert!(duration_ymdhms(b"P").is_err()); // empty duration is not 0 seconds
-    assert!(duration_ymdhms(b"P12345Y").is_err()); // years in range 0..=9999
     assert!(duration_ymdhms(b"1Y2M3DT4H5M6S").is_err()); // missing P at start
     assert!(duration_ymdhms(b"T4H5M6S").is_err()); // missing P, required even if no YMD part
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1111,6 +1111,32 @@ fn test_duration_ymdhms() {
         }),
         duration("PT42M30S")
     );
+
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 1,
+            month: 2,
+            day: 3,
+            hour: 4,
+            minute: 5,
+            second: 6,
+            millisecond: 0,
+        }),
+        duration("P0001-02-03T04:05:06")
+    );
+
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 2018,
+            month: 4,
+            day: 27,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            millisecond: 0,
+        }),
+        duration("P2018-04-27T00:00:00")
+    );
 }
 
 #[test]
@@ -1118,45 +1144,4 @@ fn test_duration_weeks() {
     assert_eq!(Ok(Duration::Weeks(0)), duration("P0W"));
     assert_eq!(Ok(Duration::Weeks(26)), duration("P26W"));
     assert_eq!(Ok(Duration::Weeks(52)), duration("P52W"));
-}
-
-#[test]
-fn test_duration_datetime() {
-    assert_eq!(
-        Ok(Duration::DateTime(DateTime {
-            date: Date::YMD {
-                year: 1,
-                month: 2,
-                day: 3,
-            },
-            time: Time {
-                hour: 4,
-                minute: 5,
-                second: 6,
-                millisecond: 0,
-                tz_offset_hours: 0,
-                tz_offset_minutes: 0,
-            }
-        })),
-        duration("P0001-02-03T04:05:06")
-    );
-
-    assert_eq!(
-        Ok(Duration::DateTime(DateTime {
-            date: Date::YMD {
-                year: 2018,
-                month: 4,
-                day: 27,
-            },
-            time: Time {
-                hour: 0,
-                minute: 0,
-                second: 0,
-                millisecond: 0,
-                tz_offset_hours: 0,
-                tz_offset_minutes: 0,
-            }
-        })),
-        duration("P2018-04-27T00:00:00")
-    );
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -956,3 +956,207 @@ fn issue12_regression_2() {
         time(input)
     );
 }
+
+#[test]
+fn test_duration_ymdhms() {
+    // full YMDHMS
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 1,
+            month: 2,
+            day: 3,
+            hour: 4,
+            minute: 5,
+            second: 6,
+            millisecond: 0,
+        }),
+        duration("P1Y2M3DT4H5M6S")
+    );
+
+    // full YMDHMS with milliseconds dot delimiter
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 1,
+            month: 2,
+            day: 3,
+            hour: 4,
+            minute: 5,
+            second: 6,
+            millisecond: 700,
+        }),
+        duration("P1Y2M3DT4H5M6.7S")
+    );
+
+    // full YMDHMS with milliseconds comma delimiter
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 1,
+            month: 2,
+            day: 3,
+            hour: 4,
+            minute: 5,
+            second: 6,
+            millisecond: 700,
+        }),
+        duration("P1Y2M3DT4H5M6,7S")
+    );
+
+    // subset YM-HM-
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 1,
+            month: 2,
+            day: 0,
+            hour: 4,
+            minute: 5,
+            second: 0,
+            millisecond: 0,
+        }),
+        duration("P1Y2MT4H5M")
+    );
+
+    // subset Y-----
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 1,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            millisecond: 0,
+        }),
+        duration("P1Y")
+    );
+
+    // subset ---H--
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 4,
+            minute: 0,
+            second: 0,
+            millisecond: 0,
+        }),
+        duration("PT4H")
+    );
+
+    // subset -----S with milliseconds dot delimiter
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 6,
+            millisecond: 700,
+        }),
+        duration("PT6.7S")
+    );
+
+    // subset -----S with milliseconds comma delimiter
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 6,
+            millisecond: 700,
+        }),
+        duration("PT6,700S")
+    );
+
+    // empty duration, using Y
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            millisecond: 0,
+        }),
+        duration("P0Y")
+    );
+
+    // empty duration, using S
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            millisecond: 0,
+        }),
+        duration("PT0S")
+    );
+
+    assert_eq!(
+        Ok(Duration::YMDHMS {
+            year: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 42,
+            second: 30,
+            millisecond: 0,
+        }),
+        duration("PT42M30S")
+    );
+}
+
+#[test]
+fn test_duration_weeks() {
+    assert_eq!(Ok(Duration::Weeks(0)), duration("P0W"));
+    assert_eq!(Ok(Duration::Weeks(26)), duration("P26W"));
+    assert_eq!(Ok(Duration::Weeks(52)), duration("P52W"));
+}
+
+#[test]
+fn test_duration_datetime() {
+    assert_eq!(
+        Ok(Duration::DateTime(DateTime {
+            date: Date::YMD {
+                year: 1,
+                month: 2,
+                day: 3,
+            },
+            time: Time {
+                hour: 4,
+                minute: 5,
+                second: 6,
+                millisecond: 0,
+                tz_offset_hours: 0,
+                tz_offset_minutes: 0,
+            }
+        })),
+        duration("P0001-02-03T04:05:06")
+    );
+
+    assert_eq!(
+        Ok(Duration::DateTime(DateTime {
+            date: Date::YMD {
+                year: 2018,
+                month: 4,
+                day: 27,
+            },
+            time: Time {
+                hour: 0,
+                minute: 0,
+                second: 0,
+                millisecond: 0,
+                tz_offset_hours: 0,
+                tz_offset_minutes: 0,
+            }
+        })),
+        duration("P2018-04-27T00:00:00")
+    );
+}


### PR DESCRIPTION
I also grouped some of the utility functions together and renamed some of the internal functions in parsers.rs to differentiate between date, time and duration parsing.

Let me know if there are desired changes, I haven't used nom before so there might be some more ergonomic ways of parsing than I came up with! 😄

Closes #23 