### PR TITLE
Expose internal parsers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use core::default::Default;
 use core::str::FromStr;
 
 mod display;
-mod parsers;
+pub mod parsers;
 
 /// A date, can hold three different formats.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]


### PR DESCRIPTION
I want to combine already existing parsers for my purpose: I need to parse `semver-version '-' date`. It would be great if I could use your library for this.