### PR TITLE
Replace rounding-error prone floating point code with robust integer code

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -22,6 +22,22 @@ fn test_date() {
 
 #[test]
 fn test_millisecond() {
+    let mut i=0;
+    while i < 1000 {
+      //regression test for pull request 36.
+      assert_eq!(
+        Ok(Time {
+            hour: 16,
+            minute: 43,
+            second: 0,
+            millisecond: i,
+            tz_offset_hours: 0,
+            tz_offset_minutes: 0
+        }),
+        time(format!("16:43:00.{:0>3}",i).as_str())
+      );
+      i+=1;
+    }
     assert_eq!(
         Ok(Time {
             hour: 16,


### PR DESCRIPTION
When this package was uploaded to Debian we noticed test failures on i386.

Debian i386 uses the x87 floating point unit which is known to have slightly different floating point behavior from other architectures due to excess precision in it's floating point registers. However when I made the testsuite more thorough I found rounding errors on amd64 as well.

     ---- test_duration_ymdhms stdout ----
     thread 'test_duration_ymdhms' panicked at 'assertion failed: `(left == right)`
       left: `Ok(YMDHMS { year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6, millisecond: 700 })`,
      right: `Ok(YMDHMS { year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6, millisecond: 699 })`', tests/lib.rs:977:5

    ---- test_millisecond stdout ----
    thread 'test_millisecond' panicked at 'assertion failed: `(left == right)`
      left: `Ok(Time { hour: 16, minute: 43, second: 0, millisecond: 120, tz_offset_hours: 0, tz_offset_minutes: 0 })`,
     right: `Ok(Time { hour: 16, minute: 43, second: 0, millisecond: 119, tz_offset_hours: 0, tz_offset_minutes: 0 })`', tests/lib.rs:36:5

The problem is that sometimes when a decimal number is converted to floating point and multiplied by 1000 the result is slightly smaller than expected due to floating point rounding. When the resulting slightly smaller number is rounded towards zero in the conversion to integer the result is a number one smaller than expected.

My fix was to avoid floating point completely and implement the milliseconds parsing using purely slicing and integer math.
