### PR TITLE
docs(README): replace broken crates.io badge with shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # omnomnom - ~~Eating~~ Parsing [ISO8601][iso] dates using [nom][]
 
-[![crates.io](http://meritbadge.herokuapp.com/iso8601)](https://crates.io/crates/iso8601)
+[![Crates.io](https://img.shields.io/crates/v/iso8601)](https://crates.io/crates/iso8601)
 [![Build Status](https://travis-ci.org/badboy/iso8601.svg?branch=master)](https://travis-ci.org/badboy/iso8601)
 
 [iso]: https://en.wikipedia.org/wiki/ISO_8601


### PR DESCRIPTION
<http://meritbadge.herokuapp.com> seems to be gone.

<https://shields.io/> seems to be the go-to badge service.