### PR TITLE
build: raise edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/iso8601/"
 license = "MIT"
 readme = "README.md"
 
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 nom = { version = "7", default-features = false }


### PR DESCRIPTION
was another suggestion by lib.rs dashboard