### PR TITLE
fix: zero-pad milliseconds in Time and Duration display

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -20,7 +20,7 @@ impl Display for Time {
         // like `16:43:16.123+00:00`
         write!(
             f,
-            "{:02}:{:02}:{:02}.{}+{:02}:{:02}",
+            "{:02}:{:02}:{:02}.{:03}+{:02}:{:02}",
             self.hour,
             self.minute,
             self.second,
@@ -80,7 +80,7 @@ impl Display for Duration {
                 }
 
                 if *millisecond > 0 {
-                    write!(f, "{}.{}S", second, millisecond)?
+                    write!(f, "{}.{:03}S", second, millisecond)?
                 } else if *second > 0 {
                     write!(f, "{}S", second)?
                 }
@@ -135,5 +135,30 @@ mod tests {
     fn display_duration_2() {
         let duration = Duration::Weeks(50);
         test_duration_reparse(duration);
+    }
+
+    #[test]
+    fn display_duration_small_milliseconds() {
+        for millisecond in [1, 10, 100] {
+            let duration = Duration::YMDHMS {
+                year: 0,
+                month: 0,
+                day: 0,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                millisecond,
+            };
+            test_duration_reparse(duration);
+        }
+    }
+
+    #[test]
+    fn display_time_small_milliseconds() {
+        let time = crate::time("16:43:16.001").unwrap();
+        assert_eq!(format!("{}", time), "16:43:16.001+00:00");
+
+        let time = crate::time("16:43:16.010").unwrap();
+        assert_eq!(format!("{}", time), "16:43:16.010+00:00");
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -108,7 +108,7 @@ mod time {
 
     #[test]
     fn serialize() {
-        let time_json = r#""18:12:15.0+00:00""#;
+        let time_json = r#""18:12:15.000+00:00""#;
 
         let deserialized_time = serde_json::from_str::<crate::Time>(time_json).unwrap();
         let serialized_time = serde_json::to_string(&deserialized_time).unwrap();
@@ -168,7 +168,7 @@ mod datetime {
 
     #[test]
     fn serialize() {
-        let datetime_json = r#""2023-02-10T18:12:15.0+00:00""#;
+        let datetime_json = r#""2023-02-10T18:12:15.000+00:00""#;
         let datetime = crate::datetime("2023-02-10T18:12:15.0+00:00").unwrap();
 
         let serialized_datetime = serde_json::to_string(&datetime).unwrap();


### PR DESCRIPTION
Milliseconds were formatted without zero-padding, so 1 ms rendered as ".1" and 10 ms as ".10" — both re-parsing as 100 ms. This made the display→parse round-trip (and serialization, which goes through Display) lossy by up to 99 ms.

Pad the millisecond field to three digits ("{:03}") so 1 ms renders as ".001" and 10 ms as ".010". Add round-trip regression tests for 1, 10, and 100 ms.